### PR TITLE
Define mocked api response

### DIFF
--- a/src/test-utils/mock-fetch.js
+++ b/src/test-utils/mock-fetch.js
@@ -14,17 +14,21 @@ const getApiResponse = url => {
 /**
  * Will return response from json-server api definition file according to requested path.
  */
-export const mockApiResponse = () => {
+export const useJsonServerResponses = () => {
   return fetch.mockResponse(req => {
     const response = getApiResponse(req.url);
     return Promise.resolve(JSON.stringify(response));
   }, init);
 };
 
+export const mockApiError = (message = 'Error') => {
+  return fetch.mockReject(new Error(message));
+};
+
 /**
  * Will return given response when next fetch api call is triggered
  */
-export const mockResponse = response => {
+export const mockApiResponse = response => {
   return fetch.mockResponse(JSON.stringify(response), init);
 };
 

--- a/src/views/backend-call/backend-call.js
+++ b/src/views/backend-call/backend-call.js
@@ -58,11 +58,12 @@ export default createReducer(initialState, {
   },
   [fetchDataFromBackendSuccess](state: BackendCallState, action) {
     state.loading = false;
-    state.response = Get(action, 'payload.response', '');
+    state.response = Get(action, 'payload.response', 'Invalid response');
     message.success('Fetch succeeded!');
   },
   [fetchDataFromBackendFailure](state: BackendCallState) {
     state.loading = false;
+    state.response = 'Failed to fetch data';
     message.error('Fetch failed');
   }
 });


### PR DESCRIPTION
It's essential that test can define exactly the response received from
api to be able to test different scenarios.

Returning only a successful api response based on json-server won't
test failure cases.

Add test cases for failure scenarios.